### PR TITLE
Restrict authors vocab to current blog

### DIFF
--- a/src/collective/blog/utils.py
+++ b/src/collective/blog/utils.py
@@ -1,21 +1,18 @@
-from Acquisition import aq_parent
+from Acquisition import aq_chain
 from collective.blog.behaviors.blog import IBlogInfo
 from plone import api
 from plone.dexterity.content import DexterityContent
-from Products.CMFPlone.Portal import IPloneSiteRoot
 
 
-_BLOG_TYPES = "BlogFolder"
+_BLOG_TYPES = ("BlogFolder",)
 
 
 def find_blog_container_uid(obj: DexterityContent) -> str:
     """Find a blog."""
-    if IBlogInfo.providedBy(obj) or obj.portal_type in _BLOG_TYPES:
-        return api.content.get_uuid(obj)
-    else:
-        # Up one level (get parent) if not reached the root of the site
-        return (
-            ""
-            if IPloneSiteRoot.providedBy(obj)
-            else find_blog_container_uid(aq_parent(obj))
-        )
+    for parent in aq_chain(obj):
+        if (
+            IBlogInfo.providedBy(parent)
+            or getattr(parent, "portal_type", "") in _BLOG_TYPES
+        ):
+            return api.content.get_uuid(parent)
+    return ""

--- a/src/collective/blog/vocabularies/authors.py
+++ b/src/collective/blog/vocabularies/authors.py
@@ -1,3 +1,4 @@
+from collective.blog.utils import find_blog_container_uid
 from plone import api
 from zope.interface import provider
 from zope.schema.interfaces import IVocabularyFactory
@@ -9,9 +10,13 @@ from zope.schema.vocabulary import SimpleVocabulary
 def authors_vocabulary(context):
     """Vocabulary of all authors."""
     terms = []
-    brains = api.content.find(portal_type="Author", sort_on="sortable_title")
-    for brain in brains:
-        token = brain.UID
-        title = brain.Title
-        terms.append(SimpleTerm(token, token, title))
+    blog_uid = find_blog_container_uid(context)
+    if blog_uid:
+        brains = api.content.find(
+            blog_uid=blog_uid, portal_type="Author", sort_on="sortable_title"
+        )
+        for brain in brains:
+            token = brain.UID
+            title = brain.Title
+            terms.append(SimpleTerm(token, token, title))
     return SimpleVocabulary(terms)

--- a/tests/vocabularies/test_vocab_authors.py
+++ b/tests/vocabularies/test_vocab_authors.py
@@ -13,7 +13,7 @@ class TestVocabAuthors:
         for authors_uid in authors:
             obj = api.content.find(UID=authors_uid)[0].getObject()
             obj.reindexObject()
-        self.vocab = get_vocabulary(self.name, portal)
+        self.vocab = get_vocabulary(self.name, portal["tech-blog"])
 
     def test_vocabulary(self):
         assert self.vocab is not None
@@ -29,3 +29,13 @@ class TestVocabAuthors:
     def test_titles(self, value: str):
         titles = [term.title for term in self.vocab._terms]
         assert value in titles
+
+    def test_excludes_authors_from_another_blog(self, get_vocabulary, portal):
+        api.content.create(
+            type="Author",
+            container=portal.dumpster.authors,
+            title="Ford Prefect",
+        )
+        vocab = get_vocabulary(self.name, portal)
+        titles = [term.title for term in vocab._terms]
+        assert "Ford Prefect" not in titles


### PR DESCRIPTION
Fixes #58 

Note: this makes the authors vocab context-dependent. That means that in volto we need to add this to the volto config:
```
  config.settings.contextualVocabularies = [
    ...config.settings.contextualVocabularies,
    'collective.blog.authors',
  ];
```

Is there a good place to document this?